### PR TITLE
revamp XML parsing, ESLint, many other tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[**.{ts, json}]
+indent_style = spaces
+indent_size = 4

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+	"root": true,
+	"parser": "@typescript-eslint/parser",
+	"env": {
+		"node": true
+	},
+	"plugins": [
+		"@typescript-eslint",
+		"jest"
+	],
+	"extends": [
+		"eslint:recommended",
+		"plugin:@typescript-eslint/recommended",
+		"plugin:jest/recommended",
+		"prettier"
+	],
+	"rules": {
+		"@typescript-eslint/no-unused-vars": "off"
+	},
+	"ignorePatterns": [
+		"lib"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This client aims to be an easy to use and lightweight implementation for the pub
 
 Install the package:
 
-```
+```shell
 npm install trias-client
 ```
 
@@ -38,6 +38,8 @@ var departuresResult = await client.getDepartures({
     id: stopsResult.stops[0].id
 });
 ```
+
+There's also an [example script](example.ts) available that demonstrates how to use `trias-client`.
 
 ## What is TRIAS?
 

--- a/example.ts
+++ b/example.ts
@@ -1,0 +1,29 @@
+import {inspect} from "util";
+import {getClient as getTriasClient} from ".";
+
+const sbbProfile = {
+	url: 'https://api.opentransportdata.swiss/trias2020',
+	requestorRef: 'derhuerst/trias-client',
+	headers: {
+		authorization: '57c5dbbbf1fe4d000100001842c323fa9ff44fbba0b9b925f0c052d1', // test key
+	},
+}
+const steinSäckingen = '8500320'
+const laufenburg = '8500322'
+
+const client = getTriasClient(sbbProfile)
+
+;(async () => {
+const {journeys} = await client.getJourneys({
+		origin: steinSäckingen,
+		destination: laufenburg,
+		departureTime: '2021-05-20T14:00+02:00',
+		maxResults: 2,
+		includeFares: true,
+	})
+	console.log(inspect(journeys, {depth: null, colors: true}))
+})()
+.catch((err) => {
+	console.error(err)
+	process.exit(1)
+})

--- a/example.ts
+++ b/example.ts
@@ -8,15 +8,17 @@ const sbbProfile = {
 		authorization: '57c5dbbbf1fe4d000100001842c323fa9ff44fbba0b9b925f0c052d1', // test key
 	},
 }
-const steinSäckingen = '8500320'
-const laufenburg = '8500322'
+const zürich = '8503000'
+const luzern = '8505000'
+const aarau = '8502113'
 
 const client = getTriasClient(sbbProfile)
 
 ;(async () => {
-const {journeys} = await client.getJourneys({
-		origin: steinSäckingen,
-		destination: laufenburg,
+	const {journeys} = await client.getJourneys({
+		origin: zürich,
+		destination: luzern,
+		via: [aarau],
 		departureTime: '2021-05-20T14:00+02:00',
 		maxResults: 2,
 		includeFares: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
             "dependencies": {
                 "@types/xmldom": "^0.1.30",
                 "axios": "^0.21.1",
+                "lodash": "^4.17.21",
                 "moment-timezone": "^0.5.33",
                 "xmldom": "^0.5.0"
             },
             "devDependencies": {
+                "@types/lodash": "^4.14.168",
                 "@types/node": "^14.14.35",
                 "@typescript-eslint/eslint-plugin": "^4.22.0",
                 "@typescript-eslint/parser": "^4.22.0",
@@ -1190,6 +1192,12 @@
             "version": "7.0.7",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
             "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+            "dev": true
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.14.168",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -5833,8 +5841,7 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
@@ -9686,6 +9693,12 @@
             "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
             "dev": true
         },
+        "@types/lodash": {
+            "version": "4.14.168",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+            "dev": true
+        },
         "@types/node": {
             "version": "14.14.35",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
@@ -13340,8 +13353,7 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.clonedeep": {
             "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "trias-client",
             "version": "0.3.0",
             "license": "ISC",
             "dependencies": {
@@ -15,12 +16,15 @@
             },
             "devDependencies": {
                 "@types/node": "^14.14.35",
+                "@typescript-eslint/eslint-plugin": "^4.22.0",
+                "@typescript-eslint/parser": "^4.22.0",
+                "eslint": "^7.25.0",
+                "eslint-config-prettier": "^8.3.0",
+                "eslint-plugin-jest": "^24.3.6",
                 "friendly-public-transport-format": "^1.2.1",
                 "jest": "^26.6.3",
                 "prettier": "^2.2.1",
                 "ts-node": "^9.1.1",
-                "tslint": "^6.1.3",
-                "tslint-config-prettier": "^1.18.0",
                 "typescript": "^4.2.3"
             }
         },
@@ -437,6 +441,50 @@
             },
             "engines": {
                 "node": ">=0.1.95"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+            "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+            "dev": true,
+            "dependencies": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "12.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -1011,6 +1059,41 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+            "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.4",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+            "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+            "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.4",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@sinonjs/commons": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -1103,6 +1186,12 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+            "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+            "dev": true
+        },
         "node_modules/@types/node": {
             "version": "14.14.35",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
@@ -1147,6 +1236,193 @@
             "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
             "dev": true
         },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
+            "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": "4.22.0",
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "debug": "^4.1.1",
+                "functional-red-black-tree": "^1.0.1",
+                "lodash": "^4.17.15",
+                "regexpp": "^3.0.0",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^4.0.0",
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
+            "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/typescript-estree": "4.22.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
+            "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/typescript-estree": "4.22.0",
+                "debug": "^4.1.1"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+            "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/visitor-keys": "4.22.0"
+            },
+            "engines": {
+                "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+            "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+            "dev": true,
+            "engines": {
+                "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+            "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/visitor-keys": "4.22.0",
+                "debug": "^4.1.1",
+                "globby": "^11.0.1",
+                "is-glob": "^4.0.1",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+            "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "4.22.0",
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "engines": {
+                "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/abab": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -1187,6 +1463,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+            "dev": true,
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
         "node_modules/acorn-walk": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -1206,6 +1491,15 @@
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/ansi-escapes": {
@@ -1296,6 +1590,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -1330,6 +1633,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/asynckit": {
@@ -1627,15 +1939,6 @@
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
-        "node_modules/builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1904,12 +2207,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
-        },
         "node_modules/component-emitter": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2122,6 +2419,30 @@
                 "node": ">= 10.14.2"
             }
         },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "dependencies": {
+                "esutils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/domexception": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2183,6 +2504,18 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-colors": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
         "node_modules/error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2230,6 +2563,355 @@
                 "node": ">=6.0"
             }
         },
+        "node_modules/eslint": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+            "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "7.12.11",
+                "@eslint/eslintrc": "^0.4.0",
+                "ajv": "^6.10.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^2.0.0",
+                "espree": "^7.3.1",
+                "esquery": "^1.4.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^6.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^13.6.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash": "^4.17.21",
+                "minimatch": "^3.0.4",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.1",
+                "progress": "^2.0.0",
+                "regexpp": "^3.1.0",
+                "semver": "^7.2.1",
+                "strip-ansi": "^6.0.0",
+                "strip-json-comments": "^3.1.0",
+                "table": "^6.0.4",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-config-prettier": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+            "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jest": {
+            "version": "24.3.6",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
+            "integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": ">= 4",
+                "eslint": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/eslint-scope/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/eslint-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
+            }
+        },
+        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/eslint/node_modules/@babel/code-frame": {
+            "version": "7.12.11",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/highlight": "^7.10.4"
+            }
+        },
+        "node_modules/eslint/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/chalk": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/eslint/node_modules/globals": {
+            "version": "13.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+            "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/optionator": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "dev": true,
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/eslint/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/espree": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+            "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^7.4.0",
+                "acorn-jsx": "^5.3.1",
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/espree/node_modules/acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2241,6 +2923,30 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "dev": true,
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/estraverse": {
@@ -2566,6 +3272,23 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
+        "node_modules/fast-glob": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+            "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2578,6 +3301,15 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "node_modules/fastq": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+            "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+            "dev": true,
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
         "node_modules/fb-watchman": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2585,6 +3317,18 @@
             "dev": true,
             "dependencies": {
                 "bser": "2.1.1"
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
+            "dependencies": {
+                "flat-cache": "^3.0.4"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -2611,6 +3355,25 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/flat-cache": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "dev": true,
+            "dependencies": {
+                "flatted": "^3.1.0",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+            "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+            "dev": true
         },
         "node_modules/follow-redirects": {
             "version": "1.13.3",
@@ -2695,6 +3458,12 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
+        "node_modules/functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2769,6 +3538,18 @@
                 "node": "*"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2776,6 +3557,35 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/globby": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globby/node_modules/ignore": {
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/graceful-fs": {
@@ -2957,6 +3767,40 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/import-local": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -3094,6 +3938,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3110,6 +3963,18 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-number": {
@@ -4865,6 +5730,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4965,10 +5836,28 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "node_modules/lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+            "dev": true
+        },
         "node_modules/lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "node_modules/lodash.truncate": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
         },
         "node_modules/lru-cache": {
@@ -5046,6 +5935,15 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/micromatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -5118,18 +6016,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
             }
         },
         "node_modules/moment": {
@@ -5499,6 +6385,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5561,6 +6459,15 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/performance-now": {
             "version": "2.1.0",
@@ -5676,6 +6583,15 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/prompts": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -5722,6 +6638,26 @@
             "engines": {
                 "node": ">=0.6"
             }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/react-is": {
             "version": "17.0.2",
@@ -5787,6 +6723,18 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/regexpp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/remove-trailing-separator": {
@@ -5879,6 +6827,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -5931,6 +6888,16 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -5950,6 +6917,29 @@
             "dev": true,
             "engines": {
                 "node": "6.* || >= 7.*"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/safe-buffer": {
@@ -6368,6 +7358,56 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/snapdragon": {
             "version": "0.8.2",
@@ -6866,6 +7906,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6918,6 +7970,46 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "node_modules/table": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
+            "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+            "dev": true,
+            "dependencies": {
+                "ajv": "^8.0.1",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/table/node_modules/ajv": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
+            "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/table/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
+        },
         "node_modules/terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -6944,6 +8036,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
         },
         "node_modules/throat": {
             "version": "5.0.0",
@@ -7071,52 +8169,19 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
-        "node_modules/tslint": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-            "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^4.0.1",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.13.1",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.3",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.13.0",
-                "tsutils": "^2.29.0"
-            },
-            "bin": {
-                "tslint": "bin/tslint"
-            },
-            "engines": {
-                "node": ">=4.8.0"
-            }
-        },
-        "node_modules/tslint-config-prettier": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
-            "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
-            "dev": true,
-            "bin": {
-                "tslint-config-prettier-check": "bin/check.js"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/tsutils": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
             "dev": true,
             "dependencies": {
                 "tslib": "^1.8.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
         "node_modules/tunnel-agent": {
@@ -7302,6 +8367,12 @@
             "bin": {
                 "uuid": "bin/uuid"
             }
+        },
+        "node_modules/v8-compile-cache": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+            "dev": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "7.1.0",
@@ -7991,6 +9062,40 @@
                 "minimist": "^1.2.0"
             }
         },
+        "@eslint/eslintrc": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+            "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                    "dev": true
+                }
+            }
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -8457,6 +9562,32 @@
                 }
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+            "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.4",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+            "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+            "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.4",
+                "fastq": "^1.6.0"
+            }
+        },
         "@sinonjs/commons": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -8549,6 +9680,12 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "@types/json-schema": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+            "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "14.14.35",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
@@ -8593,6 +9730,111 @@
             "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
             "dev": true
         },
+        "@typescript-eslint/eslint-plugin": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
+            "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "4.22.0",
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "debug": "^4.1.1",
+                "functional-red-black-tree": "^1.0.1",
+                "lodash": "^4.17.15",
+                "regexpp": "^3.0.0",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/experimental-utils": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
+            "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/typescript-estree": "4.22.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
+            "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/typescript-estree": "4.22.0",
+                "debug": "^4.1.1"
+            }
+        },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+            "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/visitor-keys": "4.22.0"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+            "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+            "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/visitor-keys": "4.22.0",
+                "debug": "^4.1.1",
+                "globby": "^11.0.1",
+                "is-glob": "^4.0.1",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+            "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.22.0",
+                "eslint-visitor-keys": "^2.0.0"
+            }
+        },
         "abab": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -8623,6 +9865,13 @@
                 }
             }
         },
+        "acorn-jsx": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+            "dev": true,
+            "requires": {}
+        },
         "acorn-walk": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -8640,6 +9889,12 @@
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
             }
+        },
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true
         },
         "ansi-escapes": {
             "version": "4.3.1",
@@ -8708,6 +9963,12 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
+        },
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -8733,6 +9994,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
         "asynckit": {
@@ -8983,12 +10250,6 @@
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
-        },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -9211,12 +10472,6 @@
                 "delayed-stream": "~1.0.0"
             }
         },
-        "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
-        },
         "component-emitter": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -9391,6 +10646,24 @@
             "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
             "dev": true
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            }
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
         "domexception": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -9445,6 +10718,15 @@
                 "once": "^1.4.0"
             }
         },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            }
+        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -9479,11 +10761,279 @@
                 "source-map": "~0.6.1"
             }
         },
+        "eslint": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+            "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.12.11",
+                "@eslint/eslintrc": "^0.4.0",
+                "ajv": "^6.10.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^2.0.0",
+                "espree": "^7.3.1",
+                "esquery": "^1.4.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^6.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^13.6.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash": "^4.17.21",
+                "minimatch": "^3.0.4",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.1",
+                "progress": "^2.0.0",
+                "regexpp": "^3.1.0",
+                "semver": "^7.2.1",
+                "strip-ansi": "^6.0.0",
+                "strip-json-comments": "^3.1.0",
+                "table": "^6.0.4",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+                    "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "13.8.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+                    "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.20.2"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "levn": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+                    "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "^1.2.1",
+                        "type-check": "~0.4.0"
+                    }
+                },
+                "optionator": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+                    "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+                    "dev": true,
+                    "requires": {
+                        "deep-is": "^0.1.3",
+                        "fast-levenshtein": "^2.0.6",
+                        "levn": "^0.4.1",
+                        "prelude-ls": "^1.2.1",
+                        "type-check": "^0.4.0",
+                        "word-wrap": "^1.2.3"
+                    }
+                },
+                "prelude-ls": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+                    "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-check": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+                    "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "^1.2.1"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-config-prettier": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+            "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+            "dev": true,
+            "requires": {}
+        },
+        "eslint-plugin-jest": {
+            "version": "24.3.6",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
+            "integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "^4.0.1"
+            }
+        },
+        "eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+            "dev": true
+        },
+        "espree": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+            "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.4.0",
+                "acorn-jsx": "^5.3.1",
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
+        },
+        "esquery": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.1.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            }
         },
         "estraverse": {
             "version": "5.2.0",
@@ -9749,6 +11299,20 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
+        "fast-glob": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+            "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9761,6 +11325,15 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fastq": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+            "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
+        },
         "fb-watchman": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -9768,6 +11341,15 @@
             "dev": true,
             "requires": {
                 "bser": "2.1.1"
+            }
+        },
+        "file-entry-cache": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^3.0.4"
             }
         },
         "fill-range": {
@@ -9788,6 +11370,22 @@
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
             }
+        },
+        "flat-cache": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "dev": true,
+            "requires": {
+                "flatted": "^3.1.0",
+                "rimraf": "^3.0.2"
+            }
+        },
+        "flatted": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+            "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+            "dev": true
         },
         "follow-redirects": {
             "version": "1.13.3",
@@ -9851,6 +11449,12 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9907,11 +11511,42 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
+        },
+        "globby": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                }
+            }
         },
         "graceful-fs": {
             "version": "4.2.6",
@@ -10056,6 +11691,30 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
         "import-local": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -10163,6 +11822,12 @@
                 "is-plain-object": "^2.0.4"
             }
         },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -10174,6 +11839,15 @@
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
         },
         "is-number": {
             "version": "7.0.0",
@@ -11587,6 +13261,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -11663,10 +13343,28 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+            "dev": true
+        },
         "lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "lodash.truncate": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
         },
         "lru-cache": {
@@ -11731,6 +13429,12 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
+        },
         "micromatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -11785,15 +13489,6 @@
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
-            }
-        },
-        "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
             }
         },
         "moment": {
@@ -12091,6 +13786,15 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
         "parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -12137,6 +13841,12 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
         "performance-now": {
@@ -12225,6 +13935,12 @@
                 }
             }
         },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
         "prompts": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -12261,6 +13977,12 @@
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
         "react-is": {
@@ -12317,6 +14039,12 @@
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
             }
+        },
+        "regexpp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "dev": true
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
@@ -12390,6 +14118,12 @@
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true
+        },
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -12433,6 +14167,12 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -12447,6 +14187,15 @@
             "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
             "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
             "dev": true
+        },
+        "run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "requires": {
+                "queue-microtask": "^1.2.2"
+            }
         },
         "safe-buffer": {
             "version": "5.2.1",
@@ -12787,6 +14536,43 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
+        },
+        "slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                }
+            }
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -13198,6 +14984,12 @@
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
         },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13240,6 +15032,41 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "table": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
+            "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+            "dev": true,
+            "requires": {
+                "ajv": "^8.0.1",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
+                    "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
+                }
+            }
+        },
         "terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -13260,6 +15087,12 @@
                 "glob": "^7.1.4",
                 "minimatch": "^3.0.4"
             }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
         },
         "throat": {
             "version": "5.0.0",
@@ -13359,37 +15192,10 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
-        "tslint": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-            "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^4.0.1",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.13.1",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.3",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.13.0",
-                "tsutils": "^2.29.0"
-            }
-        },
-        "tslint-config-prettier": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
-            "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
-            "dev": true
-        },
         "tsutils": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
@@ -13537,6 +15343,12 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
         "v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
             "dependencies": {
                 "@types/xmldom": "^0.1.30",
                 "axios": "^0.21.1",
+                "css-select": "^4.1.2",
+                "domhandler": "^4.2.0",
+                "htmlparser2": "^6.1.0",
                 "lodash": "^4.17.21",
-                "moment-timezone": "^0.5.33",
-                "xmldom": "^0.5.0"
+                "moment-timezone": "^0.5.33"
             },
             "devDependencies": {
                 "@types/lodash": "^4.14.168",
@@ -1885,6 +1887,11 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2277,6 +2284,32 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-select": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
+            "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^5.0.0",
+                "domhandler": "^4.2.0",
+                "domutils": "^2.6.0",
+                "nth-check": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
+            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/cssom": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -2451,6 +2484,30 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
+            "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
+        },
         "node_modules/domexception": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2470,6 +2527,33 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/domhandler": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+            "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
         "node_modules/ecc-jsbn": {
@@ -2522,6 +2606,14 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/error-ex": {
@@ -3738,6 +3830,24 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
+        },
+        "node_modules/htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
+            }
         },
         "node_modules/http-signature": {
             "version": "1.2.0",
@@ -6179,6 +6289,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/nth-check": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+            "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -8609,14 +8730,6 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
-        "node_modules/xmldom": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-            "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/y18n": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
@@ -10210,6 +10323,11 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10543,6 +10661,23 @@
                 "which": "^2.0.1"
             }
         },
+        "css-select": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
+            "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+            "requires": {
+                "boolbase": "^1.0.0",
+                "css-what": "^5.0.0",
+                "domhandler": "^4.2.0",
+                "domutils": "^2.6.0",
+                "nth-check": "^2.0.0"
+            }
+        },
+        "css-what": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
+            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA=="
+        },
         "cssom": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -10677,6 +10812,21 @@
                 "esutils": "^2.0.2"
             }
         },
+        "dom-serializer": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
+            "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "domelementtype": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
         "domexception": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -10692,6 +10842,24 @@
                     "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
                     "dev": true
                 }
+            }
+        },
+        "domhandler": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+            "requires": {
+                "domelementtype": "^2.2.0"
+            }
+        },
+        "domutils": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+            "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+            "requires": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
             }
         },
         "ecc-jsbn": {
@@ -10739,6 +10907,11 @@
             "requires": {
                 "ansi-colors": "^4.1.1"
             }
+        },
+        "entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -11677,6 +11850,17 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
+        },
+        "htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
+            }
         },
         "http-signature": {
             "version": "1.2.0",
@@ -13632,6 +13816,14 @@
                 "path-key": "^3.0.0"
             }
         },
+        "nth-check": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+            "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+            "requires": {
+                "boolbase": "^1.0.0"
+            }
+        },
         "nwsapi": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -15555,11 +15747,6 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
-        },
-        "xmldom": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-            "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
         },
         "y18n": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "url": "https://github.com/andaryjo/trias-client/issues"
     },
     "devDependencies": {
+        "@types/lodash": "^4.14.168",
         "@types/node": "^14.14.35",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
@@ -45,6 +46,7 @@
     "dependencies": {
         "@types/xmldom": "^0.1.30",
         "axios": "^0.21.1",
+        "lodash": "^4.17.21",
         "moment-timezone": "^0.5.33",
         "xmldom": "^0.5.0"
     },

--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
     "dependencies": {
         "@types/xmldom": "^0.1.30",
         "axios": "^0.21.1",
+        "css-select": "^4.1.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
         "lodash": "^4.17.21",
-        "moment-timezone": "^0.5.33",
-        "xmldom": "^0.5.0"
+        "moment-timezone": "^0.5.33"
     },
     "files": [
         "lib/**/*"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "build": "tsc",
         "format": "prettier --write \"src/**/*.ts\"",
-        "lint": "tslint -p tsconfig.json",
+        "lint": "eslint .",
         "test": "tsc && jest"
     },
     "jest": {
@@ -31,12 +31,15 @@
     },
     "devDependencies": {
         "@types/node": "^14.14.35",
+        "@typescript-eslint/eslint-plugin": "^4.22.0",
+        "@typescript-eslint/parser": "^4.22.0",
+        "eslint": "^7.25.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-jest": "^24.3.6",
         "friendly-public-transport-format": "^1.2.1",
         "jest": "^26.6.3",
         "prettier": "^2.2.1",
         "ts-node": "^9.1.1",
-        "tslint": "^6.1.3",
-        "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.2.3"
     },
     "dependencies": {

--- a/src/request-and-parse.ts
+++ b/src/request-and-parse.ts
@@ -1,0 +1,43 @@
+import axios, {AxiosRequestConfig, AxiosResponse} from 'axios';
+import {DOMParser} from "xmldom";
+
+export async function request(
+    url: string,
+    requestorRef: string,
+    headers: { [key: string]: string },
+    reqBody: string,
+): Promise<AxiosResponse<string>> {
+    const req: AxiosRequestConfig = {
+        url,
+        method: 'POST',
+        headers: {
+            // There are two MIME assignments for XML data. These are:
+            // - application/xml (RFC 7303, previously RFC 3023)
+            // - text/xml (RFC 7303, previously RFC 3023)
+            // https://en.wikipedia.org/wiki/XML_and_MIME
+            'content-type': 'application/xml',
+            'accept': 'application/xml',
+            ...headers,
+        },
+        data: reqBody,
+    };
+
+    const res = await axios(req);
+    return res;
+}
+
+export async function requestAndParse(
+    url: string,
+    requestorRef: string,
+    headers: { [key: string]: string },
+    reqBody: string,
+): Promise<any> { // todo: properly specify type as XML DOM node
+    const res = await request(url, requestorRef, headers, reqBody);
+
+    // Some providers include XML tags like "<trias:Result>"
+    // This function removes them from the body before parsing
+    const sanitizedBody = res.data.replace(/trias:/g, "");
+    const doc = new DOMParser().parseFromString(sanitizedBody);
+
+    return doc;
+}

--- a/src/request-and-parse.ts
+++ b/src/request-and-parse.ts
@@ -1,6 +1,8 @@
 import axios, {AxiosRequestConfig, AxiosResponse} from 'axios';
 import {DOMParser} from "xmldom";
 
+const DEBUG = /(^|,)trias-client(,|$)/.test(process.env.DEBUG || '')
+
 export async function request(
     url: string,
     requestorRef: string,
@@ -21,8 +23,12 @@ export async function request(
         },
         data: reqBody,
     };
+    // tslint:disable-next-line:no-console
+    if (DEBUG) console.error(reqBody);
 
     const res = await axios(req);
+    // tslint:disable-next-line:no-console
+    if (DEBUG) console.error(res.data);
     return res;
 }
 

--- a/src/request-and-parse.ts
+++ b/src/request-and-parse.ts
@@ -1,5 +1,18 @@
 import axios, {AxiosRequestConfig, AxiosResponse} from 'axios';
-import {DOMParser} from "xmldom";
+import {Document, Node as DOMNode, Element as DOMElement} from 'domhandler';
+import {
+    Options as CssSelectOptions,
+    selectAll as _selectAll,
+    selectOne as _selectOne,
+    compile as _compile,
+} from 'css-select';
+import {CompiledQuery} from 'css-select/lib/types';
+import {
+    getText as _getText,
+} from 'domutils';
+import {parseDocument} from 'htmlparser2';
+
+export {Element as DOMElement} from 'domhandler';
 
 const DEBUG = /(^|,)trias-client(,|$)/.test(process.env.DEBUG || '')
 
@@ -32,18 +45,63 @@ export async function request(
     return res;
 }
 
+export function selectAll(
+    query: string,
+    elements: DOMNode | DOMNode[] | null,
+    options: CssSelectOptions<DOMNode, DOMElement> = {},
+): DOMElement[] {
+    if (elements === null) return [];
+    return _selectAll(query, elements, {
+        xmlMode: true,
+        ...options,
+    });
+}
+export function selectOne(
+    query: string,
+    elements: DOMNode | DOMNode[] | null,
+    options: CssSelectOptions<DOMNode, DOMElement> = {},
+): DOMElement | null {
+    if (elements === null) return null;
+    return _selectOne(query, elements, {
+        xmlMode: true,
+        ...options,
+    });
+}
+export function compile(
+    selector: string,
+    options: CssSelectOptions<DOMNode, DOMElement> = {},
+    context: DOMNode | DOMNode[] | undefined,
+): CompiledQuery<DOMElement> {
+    return _compile(selector, {
+        xmlMode: true,
+        ...options,
+    }, context);
+}
+
+export function getText(
+    node: DOMNode | DOMNode[] | null,
+): string | null {
+    return node ? _getText(node) : null;
+}
+
 export async function requestAndParse(
     url: string,
     requestorRef: string,
     headers: { [key: string]: string },
     reqBody: string,
-): Promise<any> { // todo: properly specify type as XML DOM node
+): Promise<Document> {
     const res = await request(url, requestorRef, headers, reqBody);
 
     // Some providers include XML tags like "<trias:Result>"
     // This function removes them from the body before parsing
     const sanitizedBody = res.data.replace(/trias:/g, "");
-    const doc = new DOMParser().parseFromString(sanitizedBody);
+
+    const doc = parseDocument(sanitizedBody, {
+        xmlMode: true,
+        decodeEntities: true,
+        withStartIndices: false,
+        withEndIndices: false,
+    });
 
     return doc;
 }

--- a/src/trias/TRIASDeparturesHandler.ts
+++ b/src/trias/TRIASDeparturesHandler.ts
@@ -14,115 +14,99 @@ export class TRIASDeparturesHandler {
         this.headers = headers;
     }
 
-    getDepartures(options: DeparturesRequestOptions) {
-        return new Promise((resolve, reject) => {
-            const maxResults = options.maxResults ? options.maxResults : 20;
+    async getDepartures(options: DeparturesRequestOptions): Promise<DeparturesResult> {
+        const maxResults = options.maxResults ? options.maxResults : 20;
 
-            let time;
-            if (options.time) time = moment(options.time).tz("Europe/Berlin").format("YYYY-MM-DDTHH:mm:ss");
-            else time = moment().tz("Europe/Berlin").format("YYYY-MM-DDTHH:mm:ss");
+        let time;
+        if (options.time) time = moment(options.time).tz("Europe/Berlin").format("YYYY-MM-DDTHH:mm:ss");
+        else time = moment().tz("Europe/Berlin").format("YYYY-MM-DDTHH:mm:ss");
 
-            const payload = TRIAS_SER.replace("$STATIONID", options.id)
-                .replace("$TIME", time)
-                .replace("$MAXRESULTS", maxResults.toString())
-                .replace("$TOKEN", this.requestorRef);
+        const payload = TRIAS_SER.replace("$STATIONID", options.id)
+            .replace("$TIME", time)
+            .replace("$MAXRESULTS", maxResults.toString())
+            .replace("$TOKEN", this.requestorRef);
 
-            requestAndParse(this.url, this.requestorRef, this.headers, payload)
-            .then((doc) => {
+        const doc = await requestAndParse(this.url, this.requestorRef, this.headers, payload);
 
-                const ticker = [];
-                const departures: FPTFStopover[] = [];
+        const ticker = [];
+        const departures: FPTFStopover[] = [];
 
-                try {
+        const situationsList = doc.getElementsByTagName("PtSituation");
 
-                    const situationsList = doc.getElementsByTagName("PtSituation");
+        for (let i = 0; i < situationsList.length; i++) {
 
-                    for (let i = 0; i < situationsList.length; i++) {
+            const situationElement = situationsList.item(i);
+            const summary = situationElement?.getElementsByTagName("Summary").item(0)?.childNodes[0].nodeValue;
+            if (!summary) continue;
+            const startTime = situationElement?.getElementsByTagName("StartTime").item(0)?.childNodes[0].nodeValue;
+            const endTime = situationElement?.getElementsByTagName("EndTime").item(0)?.childNodes[0].nodeValue;
 
-                        const situationElement = situationsList.item(i);
-                        const summary = situationElement?.getElementsByTagName("Summary").item(0)?.childNodes[0].nodeValue;
-                        if (!summary) continue;
-                        const startTime = situationElement?.getElementsByTagName("StartTime").item(0)?.childNodes[0].nodeValue;
-                        const endTime = situationElement?.getElementsByTagName("EndTime").item(0)?.childNodes[0].nodeValue;
+            const now = moment().unix();
+            if (now > moment(startTime).unix() && now < moment(endTime).unix()) ticker.push(summary);
+        }
 
-                        const now = moment().unix();
-                        if (now > moment(startTime).unix() && now < moment(endTime).unix()) ticker.push(summary);
-                    }
+        const departuresList = doc.getElementsByTagName("StopEvent");
 
-                    const departuresList = doc.getElementsByTagName("StopEvent");
+        for (let i = 0; i < departuresList.length; i++) {
 
-                    for (let i = 0; i < departuresList.length; i++) {
+            const departure: FPTFStopover = {
+                type: "stopover",
+                stop: options.id,
+                line: {
+                    type: "line",
+                    id: "",
+                    line: "",
+                },
+                mode: FPTFMode.UNKNOWN,
+                direction: "",
+                departure: "",
+            };
 
-                        const departure: FPTFStopover = {
-                            type: "stopover",
-                            stop: options.id,
-                            line: {
-                                type: "line",
-                                id: "",
-                                line: "",
-                            },
-                            mode: FPTFMode.UNKNOWN,
-                            direction: "",
-                            departure: "",
-                        };
+            const departureElement = departuresList.item(i);
 
-                        const departureElement = departuresList.item(i);
+            let lineName;
+            const pubLineNameTextElement = departureElement?.getElementsByTagName("PublishedLineName").item(0)?.getElementsByTagName("Text").item(0);
+            if (pubLineNameTextElement?.childNodes?.length) lineName = pubLineNameTextElement.childNodes[0].nodeValue;
+            else lineName = departureElement?.getElementsByTagName("Name")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
+            if (lineName && departure.line) {
+                departure.line.id = lineName;
+                departure.line.line = lineName;
+            }
 
-                        let lineName;
-                        const pubLineNameTextElement = departureElement?.getElementsByTagName("PublishedLineName").item(0)?.getElementsByTagName("Text").item(0);
-                        if (pubLineNameTextElement?.childNodes?.length) lineName = pubLineNameTextElement.childNodes[0].nodeValue;
-                        else lineName = departureElement?.getElementsByTagName("Name")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
-                        if (lineName && departure.line) {
-                            departure.line.id = lineName;
-                            departure.line.line = lineName;
-                        }
+            const direction = departureElement?.getElementsByTagName("DestinationText")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
+            if (direction) departure.direction = direction;
 
-                        const direction = departureElement?.getElementsByTagName("DestinationText")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
-                        if (direction) departure.direction = direction;
+            const timetabledTime = departureElement?.getElementsByTagName("TimetabledTime")?.item(0)?.childNodes[0].nodeValue;
+            if (timetabledTime) departure.departure = this.parseResponseTime(timetabledTime);
 
-                        const timetabledTime = departureElement?.getElementsByTagName("TimetabledTime")?.item(0)?.childNodes[0].nodeValue;
-                        if (timetabledTime) departure.departure = this.parseResponseTime(timetabledTime);
+            const estimatedTime = departureElement?.getElementsByTagName("EstimatedTime")?.item(0)?.childNodes[0].nodeValue;
+            if (estimatedTime) departure.departureDelay = moment(estimatedTime).unix() - moment(timetabledTime).unix();
 
-                        const estimatedTime = departureElement?.getElementsByTagName("EstimatedTime")?.item(0)?.childNodes[0].nodeValue;
-                        if (estimatedTime) departure.departureDelay = moment(estimatedTime).unix() - moment(timetabledTime).unix();
+            const plannedBay = departureElement?.getElementsByTagName("PlannedBay")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
+            if (plannedBay) departure.departurePlatform = plannedBay;
 
-                        const plannedBay = departureElement?.getElementsByTagName("PlannedBay")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
-                        if (plannedBay) departure.departurePlatform = plannedBay;
+            const type = departureElement?.getElementsByTagName("PtMode")?.item(0)?.childNodes[0].nodeValue;
+            if (type === "bus") {
+                departure.mode = FPTFMode.BUS;
+            } else if (type === "tram") {
+                departure.mode = FPTFMode.TRAIN;
+                departure.subMode = FPTFSubmode.TRAM;
+            } else if (type === "metro") {
+                departure.mode = FPTFMode.TRAIN;
+                departure.subMode = FPTFSubmode.METRO;
+            } else if (type === "rail") {
+                departure.mode = FPTFMode.TRAIN;
+                departure.subMode = FPTFSubmode.RAIL;
+            }
 
-                        const type = departureElement?.getElementsByTagName("PtMode")?.item(0)?.childNodes[0].nodeValue;
-                        if (type === "bus") {
-                            departure.mode = FPTFMode.BUS;
-                        } else if (type === "tram") {
-                            departure.mode = FPTFMode.TRAIN;
-                            departure.subMode = FPTFSubmode.TRAM;
-                        } else if (type === "metro") {
-                            departure.mode = FPTFMode.TRAIN;
-                            departure.subMode = FPTFSubmode.METRO;
-                        } else if (type === "rail") {
-                            departure.mode = FPTFMode.TRAIN;
-                            departure.subMode = FPTFSubmode.RAIL;
-                        }
+            departures.push(departure);
+        }
 
-                        departures.push(departure);
-                    }
-
-                    const result: DeparturesResult = {
-                        success: true,
-                        departures,
-                        ticker
-                    };
-
-                    resolve(result);
-
-                } catch (error) {
-                    reject("The client encountered an error during parsing: " + error);
-                    return;
-                }
-
-            }).catch((error) => {
-                reject(error);
-            });
-        });
+        return {
+            success: true,
+            departures,
+            ticker
+        };
     }
 
     parseResponseTime(time: string) {

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -15,242 +15,225 @@ export class TRIASJourneysHandler {
         this.headers = headers;
     }
 
-    getJourneys(options: JourneyRequestOptions) {
-        return new Promise((resolve, reject) => {
-            const maxResults = options.maxResults ? options.maxResults : 5;
+    async getJourneys(options: JourneyRequestOptions): Promise<JourneysResult> {
+        const maxResults = options.maxResults ? options.maxResults : 5;
 
-            let arrTime; let depTime;
-            if (options.arrivalTime) arrTime = this.parseRequestTime(options.arrivalTime);
-            else if (options.departureTime) depTime = this.parseRequestTime(options.departureTime);
+        let arrTime; let depTime;
+        if (options.arrivalTime) arrTime = this.parseRequestTime(options.arrivalTime);
+        else if (options.departureTime) depTime = this.parseRequestTime(options.departureTime);
 
-            const payload = TRIAS_TR.replace("$ORIGIN", options.origin)
-                .replace("$DESTINATION", options.destination)
-                .replace("$DEPTIME", depTime ? depTime : "")
-                .replace("$ARRTIME", arrTime ? arrTime : "")
-                .replace("$MAXRESULTS", maxResults.toString())
-                .replace("$INCLUDE_FARES", options.includeFares ? 'true' : 'false')
-                .replace("$TOKEN", this.requestorRef);
+        const payload = TRIAS_TR.replace("$ORIGIN", options.origin)
+            .replace("$DESTINATION", options.destination)
+            .replace("$DEPTIME", depTime ? depTime : "")
+            .replace("$ARRTIME", arrTime ? arrTime : "")
+            .replace("$MAXRESULTS", maxResults.toString())
+            .replace("$INCLUDE_FARES", options.includeFares ? 'true' : 'false')
+            .replace("$TOKEN", this.requestorRef);
 
-            requestAndParse(this.url, this.requestorRef, this.headers, payload)
-            .then((doc) => {
+        const doc = await requestAndParse(this.url, this.requestorRef, this.headers, payload);
 
-                const trips: Journey[] = [];
+        const trips: Journey[] = [];
 
-                try {
+        const tripsResults = doc.getElementsByTagName("TripResult");
 
-                    const tripsResults = doc.getElementsByTagName("TripResult");
+        for (let i = 0; i < tripsResults.length; i++) {
 
-                    for (let i = 0; i < tripsResults.length; i++) {
+            const trip: Journey = {
+                type: "journey",
+                id: "",
+                legs: [],
+                tickets: [],
+            }
 
-                        const trip: Journey = {
-                            type: "journey",
-                            id: "",
-                            legs: [],
-                            tickets: [],
-                        }
+            const tripElement = tripsResults[i].getElementsByTagName('Trip')[0];
 
-                        const tripElement = tripsResults[i].getElementsByTagName('Trip')[0];
+            const tripID = tripElement.getElementsByTagName("TripId")[0].childNodes[0].nodeValue;
+            if (tripID) trip.id = tripID;
 
-                        const tripID = tripElement.getElementsByTagName("TripId")[0].childNodes[0].nodeValue;
-                        if (tripID) trip.id = tripID;
+            const legsList = tripElement.getElementsByTagName("TripLeg");
 
-                        const legsList = tripElement.getElementsByTagName("TripLeg");
+            for (let j = 0; j < legsList.length; j++) {
 
-                        for (let j = 0; j < legsList.length; j++) {
-
-                            const leg: FPTFLeg = {
-                                mode: FPTFMode.UNKNOWN,
-                                direction: "",
-                                origin: "",
-                                destination: "",
-                                departure: "",
-                                arrival: ""
-                            }
-
-                            const legElement = legsList[j];
-                            if (legElement.getElementsByTagName("TimedLeg").length > 0) {
-
-                                const origin: FPTFStop = {
-                                    type: "stop",
-                                    id: "",
-                                    name: ""
-                                }
-
-                                const legBoardElement = legElement.getElementsByTagName("LegBoard")[0];
-
-                                const startStationID = legBoardElement.getElementsByTagName("StopPointRef")[0].childNodes[0].nodeValue;
-                                if (startStationID) origin.id = this.parseStationID(startStationID);
-
-                                const startStationName = legBoardElement.getElementsByTagName("StopPointName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                if (startStationName) origin.name = startStationName;
-
-                                const startTime = legBoardElement.getElementsByTagName("TimetabledTime")[0].childNodes[0].nodeValue;
-                                if (startTime) leg.departure = this.parseResponseTime(startTime);
-
-                                if (legBoardElement.getElementsByTagName("EstimatedTime").length > 0) {
-                                    const startRealtime = legBoardElement.getElementsByTagName("EstimatedTime")[0].childNodes[0].nodeValue;
-                                    if (startRealtime) leg.departureDelay = moment(startRealtime).unix() - moment(leg.departure).unix();
-                                }
-
-                                if (legBoardElement.getElementsByTagName("PlannedBay").length > 0) {
-                                    const startPlatform = legBoardElement.getElementsByTagName("PlannedBay")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                    if (startPlatform) leg.departurePlatform = startPlatform;
-                                }
-
-                                const destination: FPTFStop = {
-                                    type: "stop",
-                                    id: "",
-                                    name: ""
-                                }
-
-                                const legAlightElement = legElement.getElementsByTagName("LegAlight")[0];
-
-                                const endStationID = legAlightElement.getElementsByTagName("StopPointRef")[0].childNodes[0].nodeValue;
-                                if (endStationID) destination.id = this.parseStationID(endStationID);
-
-                                const endStationName = legAlightElement.getElementsByTagName("StopPointName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                if (endStationName) destination.name = endStationName;
-
-                                const endTime = legAlightElement.getElementsByTagName("TimetabledTime")[0].childNodes[0].nodeValue;
-                                if (endTime) leg.arrival = this.parseResponseTime(endTime);
-
-                                if (legAlightElement.getElementsByTagName("EstimatedTime").length > 0) {
-                                    const endRealtime = legAlightElement.getElementsByTagName("EstimatedTime")[0].childNodes[0].nodeValue;
-                                    if (endRealtime) leg.arrivalDelay = moment(endRealtime).unix() - moment(leg.arrival).unix();
-                                }
-
-                                if (legAlightElement.getElementsByTagName("PlannedBay").length > 0) {
-                                    const endPlatform = legAlightElement.getElementsByTagName("PlannedBay")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                    if (endPlatform) leg.arrivalPlatform = endPlatform;
-                                }
-
-                                leg.line = {
-                                    type: "line",
-                                    id: "",
-                                    line: ""
-                                }
-
-                                const pubLineNameTextElement = legElement.getElementsByTagName("PublishedLineName")[0].getElementsByTagName("Text")[0];
-                                if (pubLineNameTextElement.childNodes.length > 0) {
-                                    const lineName = pubLineNameTextElement.childNodes[0].nodeValue;
-                                    if (lineName) {
-                                        leg.line.id = lineName;
-                                        leg.line.line = lineName;
-                                    }
-                                } else {
-                                    const lineName = legElement.getElementsByTagName("Name")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                    if (lineName) {
-                                        leg.line.id = lineName;
-                                        leg.line.line = lineName;
-                                    }
-                                }
-
-                                const direction = legElement.getElementsByTagName("DestinationText")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                if (direction) leg.direction = direction;
-
-                                const mode = legElement.getElementsByTagName("PtMode")[0].childNodes[0].nodeValue;
-                                if (mode === "bus") {
-                                    leg.mode = FPTFMode.BUS;
-                                } else if (mode === "tram") {
-                                    leg.mode = FPTFMode.TRAIN;
-                                    leg.subMode = FPTFSubmode.TRAM;
-                                } else if (mode === "metro") {
-                                    leg.mode = FPTFMode.TRAIN;
-                                    leg.subMode = FPTFSubmode.METRO;
-                                } else if (mode === "rail") {
-                                    leg.mode = FPTFMode.TRAIN;
-                                    leg.subMode = FPTFSubmode.RAIL;
-                                }
-
-                                leg.origin = origin;
-                                leg.destination = destination;
-
-                            } else if (legElement.getElementsByTagName("ContinuousLeg").length > 0 || legElement.getElementsByTagName("InterchangeLeg").length > 0) {
-
-                                const origin: FPTFLocation = {
-                                    type: "location",
-                                    name: ""
-                                }
-
-                                const legStartElement = legElement.getElementsByTagName("LegStart")[0];
-
-                                const startLocationName = legStartElement.getElementsByTagName("LocationName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                if (startLocationName) origin.name = startLocationName;
-
-                                if (legStartElement.getElementsByTagName("GeoPosition").length > 0) {
-                                    const latitude = legStartElement.getElementsByTagName("Latitude")[0].childNodes[0].nodeValue;
-                                    if (latitude) origin.latitude = parseFloat(latitude);
-
-                                    const longitude = legStartElement.getElementsByTagName("Longitude")[0].childNodes[0].nodeValue;
-                                    if (longitude) origin.longitude = parseFloat(longitude);
-                                }
-
-                                const destination: FPTFLocation = {
-                                    type: "location",
-                                    name: ""
-                                }
-
-                                const legEndElement = legElement.getElementsByTagName("LegEnd")[0];
-
-                                const endLocationName = legEndElement.getElementsByTagName("LocationName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
-                                if (endLocationName) destination.name = endLocationName;
-
-                                if (legEndElement.getElementsByTagName("GeoPosition").length > 0) {
-                                    const latitude = legEndElement.getElementsByTagName("Latitude")[0].childNodes[0].nodeValue;
-                                    if (latitude) destination.latitude = parseFloat(latitude);
-
-                                    const longitude = legEndElement.getElementsByTagName("Longitude")[0].childNodes[0].nodeValue;
-                                    if (longitude) destination.longitude = parseFloat(longitude);
-                                }
-
-                                const startTime = legElement.getElementsByTagName("TimeWindowStart")[0].childNodes[0].nodeValue;
-                                if (startTime) leg.departure = this.parseResponseTime(startTime);
-
-                                const endTime = legElement.getElementsByTagName("TimeWindowEnd")[0].childNodes[0].nodeValue;
-                                if (endTime) leg.arrival = this.parseResponseTime(endTime);
-
-                                leg.mode = FPTFMode.WALKING;
-
-                                leg.origin = origin;
-                                leg.destination = destination;
-
-                            }
-
-                            trip.legs.push(leg);
-
-                        }
-
-                        if (options.includeFares) {
-                            // todo: there might be multiple
-                            const faresEl = tripsResults[i].getElementsByTagName('TripFares')[0];
-                            const ticketEls = faresEl.getElementsByTagName('Ticket');
-                            for (let j = 0; j < ticketEls.length; j++) {
-                                const ticketEl = ticketEls[j];
-                                trip.tickets.push(this.parseResponseTicket(ticketEl));
-                            }
-                        }
-
-                        trips.push(trip);
-
-                    }
-
-                    const result: JourneysResult = {
-                        success: true,
-                        journeys: trips
-                    }
-
-                    resolve(result);
-
-
-                } catch (error) {
-                    reject("The client encountered an error during parsing: " + error);
-                    return;
+                const leg: FPTFLeg = {
+                    mode: FPTFMode.UNKNOWN,
+                    direction: "",
+                    origin: "",
+                    destination: "",
+                    departure: "",
+                    arrival: ""
                 }
 
-            }).catch((error) => {
-                reject(error);
-            });
-        });
+                const legElement = legsList[j];
+                if (legElement.getElementsByTagName("TimedLeg").length > 0) {
+
+                    const origin: FPTFStop = {
+                        type: "stop",
+                        id: "",
+                        name: ""
+                    }
+
+                    const legBoardElement = legElement.getElementsByTagName("LegBoard")[0];
+
+                    const startStationID = legBoardElement.getElementsByTagName("StopPointRef")[0].childNodes[0].nodeValue;
+                    if (startStationID) origin.id = this.parseStationID(startStationID);
+
+                    const startStationName = legBoardElement.getElementsByTagName("StopPointName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                    if (startStationName) origin.name = startStationName;
+
+                    const startTime = legBoardElement.getElementsByTagName("TimetabledTime")[0].childNodes[0].nodeValue;
+                    if (startTime) leg.departure = this.parseResponseTime(startTime);
+
+                    if (legBoardElement.getElementsByTagName("EstimatedTime").length > 0) {
+                        const startRealtime = legBoardElement.getElementsByTagName("EstimatedTime")[0].childNodes[0].nodeValue;
+                        if (startRealtime) leg.departureDelay = moment(startRealtime).unix() - moment(leg.departure).unix();
+                    }
+
+                    if (legBoardElement.getElementsByTagName("PlannedBay").length > 0) {
+                        const startPlatform = legBoardElement.getElementsByTagName("PlannedBay")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                        if (startPlatform) leg.departurePlatform = startPlatform;
+                    }
+
+                    const destination: FPTFStop = {
+                        type: "stop",
+                        id: "",
+                        name: ""
+                    }
+
+                    const legAlightElement = legElement.getElementsByTagName("LegAlight")[0];
+
+                    const endStationID = legAlightElement.getElementsByTagName("StopPointRef")[0].childNodes[0].nodeValue;
+                    if (endStationID) destination.id = this.parseStationID(endStationID);
+
+                    const endStationName = legAlightElement.getElementsByTagName("StopPointName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                    if (endStationName) destination.name = endStationName;
+
+                    const endTime = legAlightElement.getElementsByTagName("TimetabledTime")[0].childNodes[0].nodeValue;
+                    if (endTime) leg.arrival = this.parseResponseTime(endTime);
+
+                    if (legAlightElement.getElementsByTagName("EstimatedTime").length > 0) {
+                        const endRealtime = legAlightElement.getElementsByTagName("EstimatedTime")[0].childNodes[0].nodeValue;
+                        if (endRealtime) leg.arrivalDelay = moment(endRealtime).unix() - moment(leg.arrival).unix();
+                    }
+
+                    if (legAlightElement.getElementsByTagName("PlannedBay").length > 0) {
+                        const endPlatform = legAlightElement.getElementsByTagName("PlannedBay")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                        if (endPlatform) leg.arrivalPlatform = endPlatform;
+                    }
+
+                    leg.line = {
+                        type: "line",
+                        id: "",
+                        line: ""
+                    }
+
+                    const pubLineNameTextElement = legElement.getElementsByTagName("PublishedLineName")[0].getElementsByTagName("Text")[0];
+                    if (pubLineNameTextElement.childNodes.length > 0) {
+                        const lineName = pubLineNameTextElement.childNodes[0].nodeValue;
+                        if (lineName) {
+                            leg.line.id = lineName;
+                            leg.line.line = lineName;
+                        }
+                    } else {
+                        const lineName = legElement.getElementsByTagName("Name")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                        if (lineName) {
+                            leg.line.id = lineName;
+                            leg.line.line = lineName;
+                        }
+                    }
+
+                    const direction = legElement.getElementsByTagName("DestinationText")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                    if (direction) leg.direction = direction;
+
+                    const mode = legElement.getElementsByTagName("PtMode")[0].childNodes[0].nodeValue;
+                    if (mode === "bus") {
+                        leg.mode = FPTFMode.BUS;
+                    } else if (mode === "tram") {
+                        leg.mode = FPTFMode.TRAIN;
+                        leg.subMode = FPTFSubmode.TRAM;
+                    } else if (mode === "metro") {
+                        leg.mode = FPTFMode.TRAIN;
+                        leg.subMode = FPTFSubmode.METRO;
+                    } else if (mode === "rail") {
+                        leg.mode = FPTFMode.TRAIN;
+                        leg.subMode = FPTFSubmode.RAIL;
+                    }
+
+                    leg.origin = origin;
+                    leg.destination = destination;
+
+                } else if (legElement.getElementsByTagName("ContinuousLeg").length > 0 || legElement.getElementsByTagName("InterchangeLeg").length > 0) {
+
+                    const origin: FPTFLocation = {
+                        type: "location",
+                        name: ""
+                    }
+
+                    const legStartElement = legElement.getElementsByTagName("LegStart")[0];
+
+                    const startLocationName = legStartElement.getElementsByTagName("LocationName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                    if (startLocationName) origin.name = startLocationName;
+
+                    if (legStartElement.getElementsByTagName("GeoPosition").length > 0) {
+                        const latitude = legStartElement.getElementsByTagName("Latitude")[0].childNodes[0].nodeValue;
+                        if (latitude) origin.latitude = parseFloat(latitude);
+
+                        const longitude = legStartElement.getElementsByTagName("Longitude")[0].childNodes[0].nodeValue;
+                        if (longitude) origin.longitude = parseFloat(longitude);
+                    }
+
+                    const destination: FPTFLocation = {
+                        type: "location",
+                        name: ""
+                    }
+
+                    const legEndElement = legElement.getElementsByTagName("LegEnd")[0];
+
+                    const endLocationName = legEndElement.getElementsByTagName("LocationName")[0].getElementsByTagName("Text")[0].childNodes[0].nodeValue;
+                    if (endLocationName) destination.name = endLocationName;
+
+                    if (legEndElement.getElementsByTagName("GeoPosition").length > 0) {
+                        const latitude = legEndElement.getElementsByTagName("Latitude")[0].childNodes[0].nodeValue;
+                        if (latitude) destination.latitude = parseFloat(latitude);
+
+                        const longitude = legEndElement.getElementsByTagName("Longitude")[0].childNodes[0].nodeValue;
+                        if (longitude) destination.longitude = parseFloat(longitude);
+                    }
+
+                    const startTime = legElement.getElementsByTagName("TimeWindowStart")[0].childNodes[0].nodeValue;
+                    if (startTime) leg.departure = this.parseResponseTime(startTime);
+
+                    const endTime = legElement.getElementsByTagName("TimeWindowEnd")[0].childNodes[0].nodeValue;
+                    if (endTime) leg.arrival = this.parseResponseTime(endTime);
+
+                    leg.mode = FPTFMode.WALKING;
+
+                    leg.origin = origin;
+                    leg.destination = destination;
+
+                }
+
+                trip.legs.push(leg);
+
+            }
+
+            if (options.includeFares) {
+                // todo: there might be multiple
+                const faresEl = tripsResults[i].getElementsByTagName('TripFares')[0];
+                const ticketEls = faresEl.getElementsByTagName('Ticket');
+                for (let j = 0; j < ticketEls.length; j++) {
+                    const ticketEl = ticketEls[j];
+                    trip.tickets.push(this.parseResponseTicket(ticketEl));
+                }
+            }
+
+            trips.push(trip);
+
+        }
+
+        return {
+            success: true,
+            journeys: trips
+        };
     }
 
     parseStationID(id: string) {

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -25,7 +25,17 @@ export class TRIASJourneysHandler {
         if (options.arrivalTime) arrTime = this.parseRequestTime(options.arrivalTime);
         else if (options.departureTime) depTime = this.parseRequestTime(options.departureTime);
 
+        const via = (options.via || [])
+            .map((stopId) => `
+                <Via>
+                    <ViaPoint>
+                        <StopPointRef>${stopId}</StopPointRef>
+                    </ViaPoint>
+                </Via>
+            `)
+            .join('');
         const payload = TRIAS_TR.replace("$ORIGIN", options.origin)
+            .replace("$VIA", via)
             .replace("$DESTINATION", options.destination)
             .replace("$DEPTIME", depTime ? depTime : "")
             .replace("$ARRTIME", arrTime ? arrTime : "")

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -1,7 +1,6 @@
-import axios from 'axios';
 import * as moment from "moment-timezone";
-import * as xmldom from "xmldom";
 
+import {requestAndParse} from '../request-and-parse';
 import { TRIAS_TR } from "../xml/TRIAS_TR";
 
 export class TRIASJourneysHandler {
@@ -30,17 +29,13 @@ export class TRIASJourneysHandler {
                 .replace("$MAXRESULTS", maxResults.toString())
                 .replace("$TOKEN", this.requestorRef);
 
-            if (!this.headers["Content-Type"]) this.headers["Content-Type"] = "application/xml";
-
-            axios.post(this.url, payload, { headers: this.headers }).then((response) => {
-
-                const body = this.sanitizeBody(response.data);
+            requestAndParse(this.url, this.requestorRef, this.headers, payload)
+            .then((doc) => {
 
                 const trips: FPTFJourney[] = [];
 
                 try {
 
-                    const doc = new xmldom.DOMParser().parseFromString(body);
                     const tripsList = doc.getElementsByTagName("Trip");
 
                     for (let i = 0; i < tripsList.length; i++) {
@@ -257,12 +252,5 @@ export class TRIASJourneysHandler {
 
     parseResponseTime(time: string) {
         return moment(time).tz("Europe/Berlin").format();
-    }
-
-    // Some providers include XML tags like "<trias:Result>"
-    // This function removes them from the body before parsing
-    sanitizeBody(body: string) {
-        if (body.includes("trias:")) body = body.replace(/trias:/g, "");
-        return body;
     }
 }

--- a/src/trias/TRIASStopsHandler.ts
+++ b/src/trias/TRIASStopsHandler.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import * as xmldom from "xmldom";
-
+import {requestAndParse} from '../request-and-parse';
 import { TRIAS_LIR_NAME } from "../xml/TRIAS_LIR_NAME";
 import { TRIAS_LIR_POS } from "../xml/TRIAS_LIR_POS";
 
@@ -35,16 +33,12 @@ export class TRIASStopsHandler {
                 return;
             }
 
-            if (!this.headers["Content-Type"]) this.headers["Content-Type"] = "application/xml";
-
-            axios.post(this.url, payload, { headers: this.headers }).then((response) => {
-
-                const body = this.sanitizeBody(response.data);
+            requestAndParse(this.url, this.requestorRef, this.headers, payload)
+            .then((doc) => {
 
                 const stops: FPTFStop[] = [];
 
                 try {
-                    const doc = new xmldom.DOMParser().parseFromString(body);
                     const locationsList = doc.getElementsByTagName("LocationResult");
 
                     for (let i = 0; i < locationsList.length; i++) {
@@ -93,12 +87,5 @@ export class TRIASStopsHandler {
                 reject(error);
             });
         });
-    }
-
-    // Some providers include XML tags like "<trias:Result>"
-    // This function removes them from the body before parsing
-    sanitizeBody(body: string) {
-        if (body.includes("trias:")) body = body.replace(/trias:/g, "");
-        return body;
     }
 }

--- a/src/trias/TRIASStopsHandler.ts
+++ b/src/trias/TRIASStopsHandler.ts
@@ -30,6 +30,10 @@ export class TRIASStopsHandler {
                     .replace("$RADIUS", options.radius.toString())
                     .replace("$MAXRESULTS", maxResults.toString())
                     .replace("$TOKEN", this.requestorRef);
+            else {
+                reject('options.name or options.{latitude,longitude} must be passed');
+                return;
+            }
 
             if (!this.headers["Content-Type"]) this.headers["Content-Type"] = "application/xml";
 

--- a/src/trias/TRIASStopsHandler.ts
+++ b/src/trias/TRIASStopsHandler.ts
@@ -1,4 +1,4 @@
-import {requestAndParse} from '../request-and-parse';
+import {requestAndParse, selectAll, selectOne, getText} from '../request-and-parse';
 import { TRIAS_LIR_NAME } from "../xml/TRIAS_LIR_NAME";
 import { TRIAS_LIR_POS } from "../xml/TRIAS_LIR_POS";
 
@@ -35,9 +35,7 @@ export class TRIASStopsHandler {
 
         const stops: FPTFStop[] = [];
 
-        const locationsList = doc.getElementsByTagName("LocationResult");
-
-        for (let i = 0; i < locationsList.length; i++) {
+        for (const locationEl of selectAll('LocationResult', doc)) {
 
             const stop: FPTFStop = {
                 type: "stop",
@@ -45,13 +43,11 @@ export class TRIASStopsHandler {
                 name: "",
             };
 
-            const locationElement = locationsList.item(i);
-
-            const id = locationElement?.getElementsByTagName("StopPointRef")?.item(0)?.childNodes[0].nodeValue;
+            const id = getText(selectOne('StopPointRef', locationEl));
             if (id) stop.id = id;
 
-            const latitude = locationElement?.getElementsByTagName("Latitude")?.item(0)?.childNodes[0]?.nodeValue;
-            const longitude = locationElement?.getElementsByTagName("Longitude")?.item(0)?.childNodes[0]?.nodeValue;
+            const latitude = getText(selectOne('Latitude', locationEl));
+            const longitude = getText(selectOne('Longitude', locationEl));
             if (latitude && longitude) {
                 stop.location = {
                     type: "location",
@@ -60,8 +56,8 @@ export class TRIASStopsHandler {
                 };
             }
 
-            const stationName = locationElement?.getElementsByTagName("StopPointName")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
-            const locationName = locationElement?.getElementsByTagName("LocationName")?.item(0)?.getElementsByTagName("Text")?.item(0)?.childNodes[0].nodeValue;
+            const stationName = getText(selectOne('StopPointName Text', locationEl));
+            const locationName = getText(selectOne('LocationName Text', locationEl));
 
             if (locationName && stationName && !stationName.includes(locationName)) stop.name = locationName + " " + stationName;
             else if (stationName) stop.name = stationName;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -16,6 +16,7 @@ interface JourneyRequestOptions {
     departureTime?: string;
     arrivalTime?: string;
     maxResults?: number;
+    includeFares?: boolean;
 }
 
 interface StopsRequestOptions {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -13,6 +13,7 @@ interface DeparturesRequestOptions {
 interface JourneyRequestOptions {
     origin: string;
     destination: string;
+    via?: string[];
     departureTime?: string;
     arrivalTime?: string;
     maxResults?: number;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -7,10 +7,36 @@ interface DeparturesResult extends Result {
     ticker?: string[];
 }
 
+interface Journey extends FPTFJourney {
+    tickets: Ticket[];
+}
 interface JourneysResult extends Result {
-    journeys?: FPTFJourney[];
+    journeys?: Journey[];
 }
 
 interface StopsResult extends Result {
     stops?: FPTFStop[];
+}
+
+interface Ticket {
+	id: string;
+	name: string;
+	faresAuthorityRef: string;
+	faresAuthorityName: string;
+	price?: number;
+	// todo: <NetPrice>
+	currency?: string;
+	// todo: <VatRate>
+	tariffLevel?: string;
+	// todo: <TariffLevelLabel>
+	travelClass?: string; // todo: make an enum
+	// todo: <RequiredCard>
+	validFor?: string; // todo: make an enum
+	validityDuration?: string;
+	// todo: <ValidityDurationText>
+	// todo: <ValidityFareZones>
+	// todo: <ValidityAreaText>
+	// todo: <InfoUrl>
+	// todo: <SaleUrl>
+	// todo: <BookingInfo>
 }

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -23,16 +23,16 @@ interface Ticket {
 	name: string;
 	faresAuthorityRef: string;
 	faresAuthorityName: string;
-	price?: number;
+	price: number | null;
 	// todo: <NetPrice>
-	currency?: string;
+	currency: string | null;
 	// todo: <VatRate>
-	tariffLevel?: string;
+	tariffLevel: string | null;
 	// todo: <TariffLevelLabel>
-	travelClass?: string; // todo: make an enum
+	travelClass: string | null; // todo: make an enum
 	// todo: <RequiredCard>
-	validFor?: string; // todo: make an enum
-	validityDuration?: string;
+	validFor: string | null; // todo: make an enum
+	validityDuration: string | null;
 	// todo: <ValidityDurationText>
 	// todo: <ValidityFareZones>
 	// todo: <ValidityAreaText>

--- a/src/xml/TRIAS_TR.ts
+++ b/src/xml/TRIAS_TR.ts
@@ -11,6 +11,7 @@ export const TRIAS_TR = `
                     </LocationRef>
                     $DEPTIME
                 </Origin>
+                $VIA
                 <Destination>
                     <LocationRef>
                         <StopPointRef>$DESTINATION</StopPointRef>

--- a/src/xml/TRIAS_TR.ts
+++ b/src/xml/TRIAS_TR.ts
@@ -22,7 +22,7 @@ export const TRIAS_TR = `
                     <IncludeTrackSections>true</IncludeTrackSections>
                     <IncludeLegProjection>false</IncludeLegProjection>
                     <IncludeIntermediateStops>false</IncludeIntermediateStops>
-                    <IncludeFares>false</IncludeFares>
+                    <IncludeFares>$INCLUDE_FARES</IncludeFares>
                     <NumberOfResults>$MAXRESULTS</NumberOfResults>
                 </Params>
             </TripRequest>

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,7 +1,9 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const trias = require("../lib/index.js");
 
-if (process.env.TEST_CREDENTIALS) var creds = JSON.parse(process.env.TEST_CREDENTIALS);
-else var creds = require("./test-credentials.json");
+const creds = process.env.TEST_CREDENTIALS
+    ? JSON.parse(process.env.TEST_CREDENTIALS)
+    : require("./test-credentials.json");
 
 describe("Test providers", () => {
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const {parseResponse} = require('../lib/request-and-parse');
+
+const docWithTriasNs = `\
+<?xml version="1.0" encoding="UTF-8"?>
+<Trias xmlns="http://www.vdv.de/trias" version="1.2">
+	<trias:foo />
+	<bar>trias:</bar>
+	<trias:baz>_</trias:baz>
+</Trias>
+`
+
+describe('parseResponse()', () => {
+	it('should strip trias: namespace from tag names', () => {
+		const doc = parseResponse(docWithTriasNs)
+		const triasEl = doc.children.find(c => c.type === 'tag' && c.name === 'Trias')
+
+		const childTags = triasEl.children
+			.filter(c => c.type === 'tag')
+			.map(c => c.name);
+		expect(childTags).toEqual(['foo', 'bar', 'baz']) // strips NS from tag names
+
+		const barEl = triasEl.children.find(c => c.type === 'tag' && c.name === 'bar')
+		const barText = barEl.children.find(c => c.type === 'text')
+		expect(barText.data).toBe('trias:') // does not strip text content
+	});
+});

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,0 @@
-{
-    "extends": ["tslint:recommended", "tslint-config-prettier"],
-    "rules": {
-        "prefer-for-of": false
-    }
-}


### PR DESCRIPTION
First of all: Thanks for writing this client!

As part of a project, I'm currently adapting `trias-client` in order to pull fares/tickets data from a TRIAS endpoint. While experimenting with different TRIAS endpoints, I made changes that I want to contribute now.

Unfortunately, that process has made this PR a monster, containing many unrelated commits. *If* you want to review it, I advise you to do it per-commit, each commit should be well-scoped and atomic; If you don't want to review this, I'm fine with breaking it up into more focused PRs, just let me know!

**This PR mainly prepares the code base for further extensions. It also adds one tiny feature: fares/tickets parsing.**

Some comments on the changes:

- d7c0f05 This allows subsequent code (and the TypeScript type checker) to assume that `payload` is not empty/`undefined`.
- c2dbeb5 Adding an environment-variable-based debug hook allows people to debug their `trias-client`-based systems without fiddling with the code. The same mechanism has helped me provide support for `hafas-client` many times.
- f3d0f63 TSLint is deprecated, so I switched to ESLint.
- 285a8a4 I verified that the ticket parsing works with the VRN TRIAS endpoint.
- f6b2f66 Using `async`/`await` makes the code more readable and stack traces more actionable.
- fb19b58 I didn't necessarily move away from `xmldom`, I just wanted to have a mechanism that allows for convenient traversal of the DOM tree; I think having such tools will reduce boilerplate when the `trias-client` code grows. The `htmlparser2`/`domhandler`/`domutils`/`css-select` allows this, and is well-maintained and fully TypeScript-based.
- 1637d2d Just fixed the `trias:` namespace stripping in a more reliable way by hooking into the parser.