### PR TITLE
add plannedArrival/plannedDeparture

### DIFF
--- a/src/RequestAndParse.ts
+++ b/src/RequestAndParse.ts
@@ -10,7 +10,6 @@ export { Element as DOMElement } from "domhandler";
 const DEBUG = /(^|,)trias-client(,|$)/.test(process.env.DEBUG || "");
 
 export async function request(url: string, requestorRef: string, headers: { [key: string]: string }, reqBody: string): Promise<AxiosResponse<string>> {
-
     // Convert all header keys to lower case, to make sure that you actually overwrite the content-type header when specifying Content-Type
     // HTTP headers are case-insensitive, so this shouldn't be a problem
     for (const header in headers) {
@@ -28,7 +27,7 @@ export async function request(url: string, requestorRef: string, headers: { [key
             // - text/xml (RFC 7303, previously RFC 3023)
             // https://en.wikipedia.org/wiki/XML_and_MIME
             "content-type": "application/xml",
-            "accept": "application/xml",
+            accept: "application/xml",
             ...headers,
         },
         data: reqBody,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { TRIASDeparturesHandler } from "./trias/TRIASDeparturesHandler";
 import { TRIASJourneysHandler } from "./trias/TRIASJourneysHandler";
 import { TRIASStopsHandler } from "./trias/TRIASStopsHandler";
 
-export const getClient = (options: ClientOptions) : TRIASClient => {
+export const getClient = (options: ClientOptions): TRIASClient => {
     return new TRIASClient(options);
 };
 

--- a/src/trias/TRIASDeparturesHandler.ts
+++ b/src/trias/TRIASDeparturesHandler.ts
@@ -30,7 +30,6 @@ export class TRIASDeparturesHandler {
 
         if (options.includeSituations) {
             for (const situationEl of selectAll("PtSituation", doc)) {
-
                 const summary = getText(selectOne("Summary", situationEl));
                 const detail = getText(selectOne("Detail", situationEl));
                 const startTime = getText(selectOne("StartTime", situationEl));
@@ -42,8 +41,8 @@ export class TRIASDeparturesHandler {
                     description: detail || "",
                     validFrom: startTime || "",
                     validTo: endTime || "",
-                    priority: priority || ""
-                }
+                    priority: priority || "",
+                };
 
                 situations.push(situation);
             }
@@ -101,7 +100,7 @@ export class TRIASDeparturesHandler {
         const result: DeparturesResult = {
             success: true,
             departures,
-        }
+        };
         if (options.includeSituations) result.situations = situations;
 
         return result;

--- a/src/trias/TRIASDeparturesHandler.ts
+++ b/src/trias/TRIASDeparturesHandler.ts
@@ -71,6 +71,7 @@ export class TRIASDeparturesHandler {
             const direction = getText(selectOne("DestinationText Text", departureEl));
             if (direction) departure.direction = direction;
 
+            // todo: planned*
             const timetabledTime = getText(selectOne("TimetabledTime", departureEl));
             if (timetabledTime) departure.departure = this.parseResponseTime(timetabledTime);
 

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -23,8 +23,7 @@ export class TRIASJourneysHandler {
         if (options.arrivalTime) arrTime = this.parseRequestTime(options.arrivalTime);
         else if (options.departureTime) depTime = this.parseRequestTime(options.departureTime);
 
-        const via = (options.via || [])
-            .map((stationID) => this.parseRequestViaStation(stationID)).join("");
+        const via = (options.via || []).map((stationID) => this.parseRequestViaStation(stationID)).join("");
 
         const payload = TRIAS_TR.replace("$ORIGIN", options.origin)
             .replace("$VIA", via)
@@ -42,7 +41,6 @@ export class TRIASJourneysHandler {
 
         if (options.includeSituations) {
             for (const situationEl of selectAll("PtSituation", doc)) {
-
                 const summary = getText(selectOne("Summary", situationEl));
                 const detail = getText(selectOne("Detail", situationEl));
                 const startTime = getText(selectOne("StartTime", situationEl));
@@ -54,8 +52,8 @@ export class TRIASJourneysHandler {
                     description: detail || "",
                     validFrom: startTime || "",
                     validTo: endTime || "",
-                    priority: priority || ""
-                }
+                    priority: priority || "",
+                };
 
                 situations.push(situation);
             }
@@ -230,7 +228,7 @@ export class TRIASJourneysHandler {
         const result: JourneysResult = {
             success: true,
             journeys: trips,
-        }
+        };
         if (options.includeSituations) result.situations = situations;
 
         return result;

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -138,6 +138,9 @@ export class TRIASJourneysHandler {
                         line: "",
                     };
 
+                    const tripId = getText(selectOne("JourneyRef", legEl));
+                    if (tripId) leg.tripId = tripId;
+
                     const lineId = getText(selectOne("LineRef", legEl));
                     if (lineId && leg.line) leg.line.id = lineId;
                     const lineName = getText(selectOne("PublishedLineName Text", legEl));

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -95,10 +95,13 @@ export class TRIASJourneysHandler {
                     if (startStationName) origin.name = startStationName;
 
                     const startTime = getText(selectOne("TimetabledTime", legBoardEl));
-                    if (startTime) leg.departure = this.parseResponseTime(startTime);
+                    if (startTime) leg.departure = leg.plannedDeparture = this.parseResponseTime(startTime);
 
                     const startRealtime = getText(selectOne("EstimatedTime", legBoardEl));
-                    if (startRealtime) leg.departureDelay = moment(startRealtime).unix() - moment(leg.departure).unix();
+                    if (startRealtime) {
+                        leg.departure = this.parseResponseTime(startRealtime);
+                        leg.departureDelay = moment(leg.departure).unix() - moment(leg.plannedDeparture).unix();
+                    }
 
                     const startPlatform = getText(selectOne("PlannedBay Text", legBoardEl));
                     if (startPlatform) leg.departurePlatform = startPlatform;
@@ -118,10 +121,13 @@ export class TRIASJourneysHandler {
                     if (endStationName) destination.name = endStationName;
 
                     const endTime = getText(selectOne("TimetabledTime", legAlightEl));
-                    if (endTime) leg.arrival = this.parseResponseTime(endTime);
+                    if (endTime) leg.arrival = leg.plannedArrival = this.parseResponseTime(endTime);
 
                     const endRealtime = getText(selectOne("EstimatedTime", legAlightEl));
-                    if (endRealtime) leg.arrivalDelay = moment(endRealtime).unix() - moment(leg.arrival).unix();
+                    if (endRealtime) {
+                        leg.arrival = this.parseResponseTime(endRealtime);
+                        leg.arrivalDelay = moment(leg.arrival).unix() - moment(leg.plannedArrival).unix();
+                    }
 
                     const endPlatform = getText(selectOne("PlannedBay Text", legAlightEl));
                     if (endPlatform) leg.arrivalPlatform = endPlatform;

--- a/src/trias/TRIASJourneysHandler.ts
+++ b/src/trias/TRIASJourneysHandler.ts
@@ -138,11 +138,10 @@ export class TRIASJourneysHandler {
                         line: "",
                     };
 
-                    const lineName = getText(selectOne("PublishedLineName Text", legEl)) || getText(selectOne("Name Text", legEl));
-                    if (lineName && leg.line) {
-                        leg.line.id = lineName;
-                        leg.line.line = lineName;
-                    }
+                    const lineId = getText(selectOne("LineRef", legEl));
+                    if (lineId && leg.line) leg.line.id = lineId;
+                    const lineName = getText(selectOne("PublishedLineName Text", legEl));
+                    if (lineName && leg.line) leg.line.line = lineName;
 
                     const direction = getText(selectOne("DestinationText Text", legEl));
                     if (direction) leg.direction = direction;

--- a/src/types/fptf.ts
+++ b/src/types/fptf.ts
@@ -112,7 +112,7 @@ interface Ticket {
 }
 
 interface Situation {
-    title: string,
+    title: string;
     description: string;
     validFrom: string;
     validTo: string;

--- a/src/types/fptf.ts
+++ b/src/types/fptf.ts
@@ -52,15 +52,18 @@ interface FPTFJourney {
 }
 
 interface FPTFLeg {
+    tripId?: string; // Not included in FPTF
     line?: FPTFLine; // Not included in FPTF
     mode: FPTFMode;
     subMode?: FPTFSubmode;
     direction: string; // Not included in FPTF
     origin: string | FPTFStop | FPTFLocation;
     destination: string | FPTFStop | FPTFLocation;
+    plannedDeparture?: string; // Not included in FPTF
     departure: string;
     departureDelay?: number;
     departurePlatform?: string;
+    plannedArrival?: string; // Not included in FPTF
     arrival: string;
     arrivalDelay?: number;
     arrivalPlatform?: string;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -15,3 +15,26 @@ interface JourneysResult extends Result {
 interface StopsResult extends Result {
     stops?: FPTFStop[];
 }
+
+interface Ticket {
+    id: string;
+    name: string;
+    faresAuthorityRef: string;
+    faresAuthorityName: string;
+    price: number | null;
+    // todo: <NetPrice>
+    currency: string | null;
+    // todo: <VatRate>
+    tariffLevel: string | null;
+    // todo: <TariffLevelLabel>
+    travelClass: string | null; // todo: make an enum
+    // todo: <RequiredCard>
+    validFor: string | null; // todo: make an enum
+    validityDuration: string | null;
+    // todo: <ValidityDurationText>
+    // todo: <ValidityFareZones>
+    // todo: <ValidityAreaText>
+    // todo: <InfoUrl>
+    // todo: <SaleUrl>
+    // todo: <BookingInfo>
+}

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -15,4 +15,3 @@ interface JourneysResult extends Result {
 interface StopsResult extends Result {
     stops?: FPTFStop[];
 }
-


### PR DESCRIPTION
This PR adds `plannedArrival`/`plannedDeparture` to journey legs.

Note sure if you want this in `trias-client` or not. In https://github.com/public-transport/friendly-public-transport-format/issues/61 there has been a lot of discussion about this, as you've probably seen (I need to reply to you!), and it looks like FPTF v2 will have these fields; Also, `hafas-client` already has them today.

Keep in mind that the `leg.line.id` change (40fcc97) is a breaking change!

still to do:

- [ ] add `plannedWhen` to arrivals/departures
- [ ] do you want to adapt the tests?